### PR TITLE
Changed call interface exposing acl, renaming meta, & more.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ npm install --save s3-policy-v4
 ```javascript
 import S3Policy from 's3-policy-v4';
 
+```javascript
 const policy = S3Policy.generate({
   key: 'S3_OBJECT_KEY',
   bucket: 'S3_BUCKET_NAME',
@@ -20,10 +21,14 @@ const policy = S3Policy.generate({
   region: 'S3_BUCKET_REGION',
   accessKey: 'S3_ACCESS_KEY',
   secretKey: 'S3_SECRET_KEY',
-  metadata: {'x-amz-meta-lat': '41.891',...} (optional)
-})
+  acl: 'ACL',                                  // e.g. 'public-read'
+  conditions: [                                // all the fiddly conditions to
+    ['content-length-range', 0, 1048579],      // your heart's desire!
+    ['starts-with', '$Content-Type', 'image/'],
+    {bucket: 'mr-bucket'}
+  ]
+});
 ```
-
 
 ### TODO
 

--- a/package.json
+++ b/package.json
@@ -3,11 +3,16 @@
   "version": "0.0.3",
   "description": "Amazon AWS S3 Upload Policy Generator with Signature Version 4",
   "main": "lib/index.js",
+  "files": [
+    "lib/",
+    "LICENSE"
+  ],
   "scripts": {
     "babel": "BABEL_ENV=babel babel src --out-dir lib",
     "babel-watch": "BABEL_ENV=babel babel src --watch --out-dir lib",
     "start": "npm run babel",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "prepublish": "npm run babel"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I started down the road of adding multipart uploads to our application this afternoon and wanted to expose a few things to the top-level interface of `s3-policy-v4`. It's a great start on a useful module!

Added:
   * exposed ACL
   * npm prepublish hook

Changed:
   * meta is now called `conditions` to match S3 docs
      * conditions can handle a mix of array elements and objects
   * more robust parameter validations
   * moderate code refactor